### PR TITLE
Bump version

### DIFF
--- a/pytest_celery.py
+++ b/pytest_celery.py
@@ -2,4 +2,4 @@
 pytest-celery a shim pytest plugin to enable celery.contrib.pytest
 """
 
-__version__ = "0.0.0"
+__version__ = "0.0.1"


### PR DESCRIPTION
Please consider bump version of this shim to not force users use something like `pytest-celery>=0.0.0` in their requirements / setup.py files. 