### PR TITLE
Worker container Celery app can now be pre-configured before the worker starts

### DIFF
--- a/src/pytest_celery/vendors/worker/Dockerfile
+++ b/src/pytest_celery/vendors/worker/Dockerfile
@@ -25,6 +25,8 @@ RUN pip install --no-cache-dir --upgrade pip \
 # The workdir must be /app
 WORKDIR /app
 
+COPY app.py app.py
+
 # Switch to the test_user
 USER test_user
 

--- a/src/pytest_celery/vendors/worker/app.py
+++ b/src/pytest_celery/vendors/worker/app.py
@@ -1,13 +1,23 @@
+import json
 import logging
 import sys
 
 from celery import Celery
 from celery.signals import after_setup_logger
 
-# Will be replaced with the import strings at runtime
-{}
+config_updates = None
+name = "celery_test_app"  # Default name if not provided by the initial content
 
-app = Celery("celery_test_app")
+# Will be populated accoring to the initial content
+{0}
+{1}
+app = Celery(name)
+
+{2}
+
+if config_updates:
+    app.config_from_object(config_updates)
+    print(f"Config updates from default_worker_app fixture: {json.dumps(config_updates, indent=4)}")
 
 
 @after_setup_logger.connect

--- a/src/pytest_celery/vendors/worker/fixtures.py
+++ b/src/pytest_celery/vendors/worker/fixtures.py
@@ -20,11 +20,11 @@ from pytest_celery.vendors.worker.defaults import WORKER_DOCKERFILE_ROOTDIR
 def celery_setup_worker(
     default_worker_cls: Type[CeleryTestWorker],
     default_worker_container: CeleryWorkerContainer,
-    celery_setup_app: Celery,
+    default_worker_app: Celery,
 ) -> CeleryTestWorker:
     worker = default_worker_cls(
         container=default_worker_container,
-        app=celery_setup_app,
+        app=default_worker_app,
     )
     yield worker
     worker.teardown()
@@ -103,10 +103,12 @@ def default_worker_initial_content(
     default_worker_container_cls: Type[CeleryWorkerContainer],
     default_worker_tasks: set,
     default_worker_signals: set,
+    default_worker_app: Celery,
 ) -> dict:
     yield default_worker_container_cls.initial_content(
         worker_tasks=default_worker_tasks,
         worker_signals=default_worker_signals,
+        worker_app=default_worker_app,
     )
 
 
@@ -118,3 +120,8 @@ def default_worker_tasks(default_worker_container_cls: Type[CeleryWorkerContaine
 @pytest.fixture
 def default_worker_signals(default_worker_container_cls: Type[CeleryWorkerContainer]) -> set:
     yield default_worker_container_cls.signals_modules()
+
+
+@pytest.fixture
+def default_worker_app(celery_setup_app: Celery) -> Celery:
+    yield celery_setup_app

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -79,13 +79,22 @@ def default_worker_container_cls() -> Type[CeleryWorkerContainer]:
 def worker_test_container_initial_content(
     default_worker_container_cls: Type[CeleryWorkerContainer],
     worker_test_container_tasks: set,
+    worker_test_container_signals: set,
 ) -> dict:
-    yield default_worker_container_cls.initial_content(worker_test_container_tasks)
+    yield default_worker_container_cls.initial_content(
+        worker_tasks=worker_test_container_tasks,
+        worker_signals=worker_test_container_signals,
+    )
 
 
 @pytest.fixture(scope="session")
 def worker_test_container_tasks(default_worker_container_cls: Type[CeleryWorkerContainer]) -> set:
     yield default_worker_container_cls.tasks_modules()
+
+
+@pytest.fixture(scope="session")
+def worker_test_container_signals(default_worker_container_cls: Type[CeleryWorkerContainer]) -> set:
+    yield default_worker_container_cls.signals_modules()
 
 
 worker_test_container = container(

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
 commands =
     tox -e py311-unit,py311-integration,py311-smoke -p auto -o -- --exitfirst -n auto \
-    --reruns 10 --reruns-delay 20 --rerun-except AssertionError {posargs}
+    --reruns 15 --reruns-delay 10 --rerun-except AssertionError {posargs}
 
 [testenv:mypy]
 commands_pre =


### PR DESCRIPTION
Using a Celery obj, e.g:
```python
@pytest.fixture
def default_worker_app(default_worker_app: Celery) -> Celery:
    app = default_worker_app
    app.conf.worker_prefetch_multiplier = 1
    app.conf.worker_concurrency = 1
    yield app
```

Will set the worker with the matching configuration, practically making it able to process up to max 1 task at a time.