### PR TITLE
Update celery.current_app after a container restarts

### DIFF
--- a/src/pytest_celery/api/base.py
+++ b/src/pytest_celery/api/base.py
@@ -10,6 +10,7 @@ from celery import Celery
 from pytest_docker_tools.wrappers.container import wait_for_callable
 
 from pytest_celery.api.container import CeleryTestContainer
+from pytest_celery.defaults import CONTAINER_TIMEOUT
 from pytest_celery.defaults import RESULT_TIMEOUT
 
 
@@ -61,7 +62,7 @@ class CeleryTestNode:
             self.container.reload()
 
     def restart(self, reload_container: bool = True) -> None:
-        self.container.restart()
+        self.container.restart(timeout=CONTAINER_TIMEOUT)
         if reload_container:
             self.container.reload()
         if self.app:

--- a/src/pytest_celery/api/base.py
+++ b/src/pytest_celery/api/base.py
@@ -64,6 +64,8 @@ class CeleryTestNode:
         self.container.restart()
         if reload_container:
             self.container.reload()
+        if self.app:
+            self.app.set_current()
 
     def teardown(self) -> None:
         self.container.teardown()


### PR DESCRIPTION
Allows to restart a component (e.g., broker) and have the component object automatically working with the celery architecture after a restart, even if some attributes (e.g., container ports on the host machine/testing running machine) have been changed.