### PR TITLE
Removed memcached backend from default celery setup matrix

### DIFF
--- a/src/pytest_celery/defaults.py
+++ b/src/pytest_celery/defaults.py
@@ -30,10 +30,14 @@ CELERY_BROKER_CLUSTER = "celery_broker_cluster"
 # Fixtures collections
 ######################
 
+# These collections define which components are used by
+# pytest-celery by default. If not specified otherwise, the
+# user's tests will have a matrix of all possible combinations automatically
+
 ALL_CELERY_WORKERS = (CELERY_SETUP_WORKER,)
 ALL_CELERY_BACKENDS = (
     CELERY_REDIS_BACKEND,
-    CELERY_MEMCACHED_BACKEND,
+    # CELERY_MEMCACHED_BACKEND,  # Beta support at the moment, to be used manually
 )
 ALL_CELERY_BROKERS = (
     CELERY_REDIS_BROKER,

--- a/tests/smoke/test_canvas.py
+++ b/tests/smoke/test_canvas.py
@@ -106,3 +106,6 @@ class test_canvas:
             )
             res = sig.apply_async(queue=queue)
             assert res.get(timeout=RESULT_TIMEOUT) == ["body_task"] * 3
+
+    def test_replace(self, celery_setup: CeleryTestSetup):
+        pytest.skip("Not implemented")


### PR DESCRIPTION
To be configured manually if needed by a specific test.