### PR TITLE
Using pytest-xdist config: --dist=loadscope

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ commands_pre =
     poetry install --with dev,test
 commands =
     unit: python3 -m pytest tests/unit/ --maxfail=3 {posargs}
-    integration: python3 -m pytest tests/integration/ --exitfirst {posargs}
-    smoke: python3 -m pytest tests/smoke/ --exitfirst {posargs}
+    integration: python3 -m pytest tests/integration/ --exitfirst --dist=loadscope {posargs}
+    smoke: python3 -m pytest tests/smoke/ --exitfirst --dist=loadscope {posargs}
 basepython =
     3.8: py38
     3.9: py39
@@ -50,16 +50,20 @@ setenv =
     PYTHONUNBUFFERED = 1
     PYTHONDONTWRITEBYTECODE = 1
 commands =
-    python3 -m pytest tests --exitfirst -n auto \
-    --reruns 5 --rerun-except AssertionError {posargs}
+    python3 -m pytest tests --exitfirst \
+    -n auto --dist=loadscope \
+    --reruns 5 --rerun-except AssertionError \
+    {posargs}
 
 [testenv:parallel]
 setenv =
     PYTHONUNBUFFERED = 1
     PYTHONDONTWRITEBYTECODE = 1
 commands =
-    tox -e py312-unit,py312-integration,py312-smoke -p auto -o -- --exitfirst -n auto \
-    --reruns 5 --reruns-delay 60 --rerun-except AssertionError {posargs}
+    tox -e py312-unit,py312-integration,py312-smoke -p auto -o -- --exitfirst \
+    -n auto --dist=loadscope \
+    --reruns 5 --reruns-delay 60 --rerun-except AssertionError \
+    {posargs}
 
 [testenv:mypy]
 commands_pre =


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst#pytest-xdist-350-2023-11-21
> pytest-xdist 3.5.0 (2023-11-21)
> 
> Features
> 
> https://github.com/pytest-dev/pytest-xdist/issues/632: --dist=loadscope now sorts scopes by number of tests to assign largest scopes early -- in many cases this should improve overall test session running time, as there is less chance of a large scope being left to be processed near the end of the session, leaving other workers idle.