### PR TITLE
Dependabot job for weekly: poetry update --with test,dev,ci,docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/update-poetry-lock.yml
+++ b/.github/workflows/update-poetry-lock.yml
@@ -1,0 +1,33 @@
+name: Update Poetry Lock
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  update-lock:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install Poetry
+      run: pip install poetry
+
+    - name: Update dependencies and commit poetry.lock
+      run: |
+        poetry update --with test,dev,ci,docs
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add poetry.lock
+        git commit -m "Update poetry.lock" || echo "No changes to commit"
+        git push


### PR DESCRIPTION
Uses an additional GitHub workflow to commit a new poetry.lock (if needed) to the dependabot PR to allow fully automating package updates