### PR TITLE
Do not install Celery by default, use extra [celery] instead

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
     post_install:
-      - poetry install --with docs
+      - poetry install -E "celery" --with docs
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/examples/django/requirements.txt
+++ b/examples/django/requirements.txt
@@ -1,6 +1,5 @@
-
 sqlalchemy>=1.2.18
 django>=2.2.1
 pytest-django>=4.7.0
-git+https://github.com/celery/pytest-celery.git
+git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
 pytest-xdist>=3.5.0

--- a/examples/myworker/requirements.txt
+++ b/examples/myworker/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=7.4.4
-git+https://github.com/celery/pytest-celery.git
+git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
 pytest-xdist>=3.5.0

--- a/examples/rabbitmq_management/requirements.txt
+++ b/examples/rabbitmq_management/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=7.4.4
-git+https://github.com/celery/pytest-celery.git
+git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
 pytest-xdist>=3.5.0

--- a/examples/range/requirements.txt
+++ b/examples/range/requirements.txt
@@ -1,4 +1,4 @@
 pytest>=7.4.4
-git+https://github.com/celery/pytest-celery.git
+git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
 pytest-xdist>=3.5.0
 pytest-subtests>=0.11.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,7 +26,7 @@ files = [
 name = "amqp"
 version = "5.2.0"
 description = "Low-level AMQP client for Python (fork of amqplib)."
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "amqp-5.2.0-py3-none-any.whl", hash = "sha256:827cb12fb0baa892aad844fd95258143bce4027fdac4fccddbc43330fd281637"},
@@ -54,7 +54,7 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
@@ -131,7 +131,7 @@ dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 name = "backports-zoneinfo"
 version = "0.2.1"
 description = "Backport of the standard library zoneinfo module"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
@@ -162,7 +162,7 @@ tzdata = ["tzdata"]
 name = "billiard"
 version = "4.2.0"
 description = "Python multiprocessing fork with improvements and bugfixes"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "billiard-4.2.0-py3-none-any.whl", hash = "sha256:07aa978b308f334ff8282bd4a746e681b3513db5c9a514cbdd810cbbdc19714d"},
@@ -273,13 +273,13 @@ files = [
 
 [[package]]
 name = "celery"
-version = "5.3.6"
+version = "5.4.0rc1"
 description = "Distributed Task Queue."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "celery-5.3.6-py3-none-any.whl", hash = "sha256:9da4ea0118d232ce97dff5ed4974587fb1c0ff5c10042eb15278487cdd27d1af"},
-    {file = "celery-5.3.6.tar.gz", hash = "sha256:870cc71d737c0200c397290d730344cc991d13a057534353d124c9380267aab9"},
+    {file = "celery-5.4.0rc1-py3-none-any.whl", hash = "sha256:0c1067c4b53b5d1a62bdde7a643452ab05e078f5370b5c8e2f2ed50d9ee79c4c"},
+    {file = "celery-5.4.0rc1.tar.gz", hash = "sha256:b7ae1bd7a87ffa9afa1662393032de70188446374abe9f2dfb97c2fa30d9071c"},
 ]
 
 [package.dependencies]
@@ -291,14 +291,14 @@ click-plugins = ">=1.1.1"
 click-repl = ">=0.2.0"
 kombu = ">=5.3.4,<6.0"
 python-dateutil = ">=2.8.2"
-python-memcached = {version = "1.59", optional = true, markers = "extra == \"pymemcache\""}
+python-memcached = {version = ">=1.61", optional = true, markers = "extra == \"pymemcache\""}
 redis = {version = ">=4.5.2,<4.5.5 || >4.5.5,<6.0.0", optional = true, markers = "extra == \"redis\""}
 tzdata = ">=2022.7"
 vine = ">=5.1.0,<6.0"
 
 [package.extras]
 arangodb = ["pyArango (>=2.0.2)"]
-auth = ["cryptography (==41.0.5)"]
+auth = ["cryptography (==41.0.7)"]
 azureblockblob = ["azure-storage-blob (>=12.15.0)"]
 brotli = ["brotli (>=1.0.0)", "brotlipy (>=0.7.0)"]
 cassandra = ["cassandra-driver (>=3.25.0,<4)"]
@@ -308,16 +308,16 @@ couchbase = ["couchbase (>=3.0.0)"]
 couchdb = ["pycouchdb (==1.14.2)"]
 django = ["Django (>=2.2.28)"]
 dynamodb = ["boto3 (>=1.26.143)"]
-elasticsearch = ["elastic-transport (<=8.10.0)", "elasticsearch (<=8.11.0)"]
+elasticsearch = ["elastic-transport (<=8.11.0)", "elasticsearch (<=8.11.1)"]
 eventlet = ["eventlet (>=0.32.0)"]
 gevent = ["gevent (>=1.5.0)"]
 librabbitmq = ["librabbitmq (>=2.0.0)"]
 memcache = ["pylibmc (==1.6.3)"]
 mongodb = ["pymongo[srv] (>=4.0.2)"]
 msgpack = ["msgpack (==1.0.7)"]
-pymemcache = ["python-memcached (==1.59)"]
+pymemcache = ["python-memcached (>=1.61)"]
 pyro = ["pyro4 (==4.82)"]
-pytest = ["pytest-celery (==0.0.0)"]
+pytest = ["pytest-celery (==1.0.0b1)"]
 redis = ["redis (>=4.5.2,!=4.5.5,<6.0.0)"]
 s3 = ["boto3 (>=1.26.143)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
@@ -572,7 +572,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "click-didyoumean"
 version = "0.3.0"
 description = "Enables git-like *did-you-mean* feature in click"
-optional = false
+optional = true
 python-versions = ">=3.6.2,<4.0.0"
 files = [
     {file = "click-didyoumean-0.3.0.tar.gz", hash = "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"},
@@ -586,7 +586,7 @@ click = ">=7"
 name = "click-plugins"
 version = "1.1.1"
 description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "click-plugins-1.1.1.tar.gz", hash = "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b"},
@@ -603,7 +603,7 @@ dev = ["coveralls", "pytest (>=3.6)", "pytest-cov", "wheel"]
 name = "click-repl"
 version = "0.3.0"
 description = "REPL plugin for Click"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9"},
@@ -1169,7 +1169,7 @@ testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)",
 name = "kombu"
 version = "5.3.5"
 description = "Messaging library for Python."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "kombu-5.3.5-py3-none-any.whl", hash = "sha256:0eac1bbb464afe6fb0924b21bf79460416d25d8abc52546d4f16cad94f789488"},
@@ -1623,7 +1623,7 @@ virtualenv = ">=20.10.0"
 name = "prompt-toolkit"
 version = "3.0.43"
 description = "Library for building powerful interactive command lines in Python"
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 files = [
     {file = "prompt_toolkit-3.0.43-py3-none-any.whl", hash = "sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6"},
@@ -2064,7 +2064,7 @@ testing = ["filelock"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -2076,17 +2076,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-memcached"
-version = "1.59"
+version = "1.62"
 description = "Pure python memcached client"
-optional = false
+optional = true
 python-versions = "*"
 files = [
-    {file = "python-memcached-1.59.tar.gz", hash = "sha256:a2e28637be13ee0bf1a8b6843e7490f9456fd3f2a4cb60471733c7b5d5557e4f"},
-    {file = "python_memcached-1.59-py2.py3-none-any.whl", hash = "sha256:4dac64916871bd3550263323fc2ce18e1e439080a2d5670c594cf3118d99b594"},
+    {file = "python-memcached-1.62.tar.gz", hash = "sha256:0285470599b7f593fbf3bec084daa1f483221e68c1db2cf1d846a9f7c2655103"},
+    {file = "python_memcached-1.62-py2.py3-none-any.whl", hash = "sha256:1bdd8d2393ff53e80cd5e9442d750e658e0b35c3eebb3211af137303e3b729d1"},
 ]
-
-[package.dependencies]
-six = ">=1.4.0"
 
 [[package]]
 name = "pytz"
@@ -2298,7 +2295,7 @@ full = ["numpy"]
 name = "redis"
 version = "5.0.1"
 description = "Python client for Redis database and key-value store"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "redis-5.0.1-py3-none-any.whl", hash = "sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f"},
@@ -2906,7 +2903,7 @@ files = [
 name = "tzdata"
 version = "2023.4"
 description = "Provider of IANA time zone data"
-optional = false
+optional = true
 python-versions = ">=2"
 files = [
     {file = "tzdata-2023.4-py2.py3-none-any.whl", hash = "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3"},
@@ -2933,7 +2930,7 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "vine"
 version = "5.1.0"
 description = "Python promises."
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc"},
@@ -2964,7 +2961,7 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 name = "wcwidth"
 version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
@@ -3070,7 +3067,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+celery = ["celery"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8,<4.0"
-content-hash = "0af37a0a8586c033e2124f8a02759444a1fdd89e9eaddd4fa4e277a4ca48a20d"
+content-hash = "53ad40e16c66913a1c8a3c91f1b088b4f50d6a2aa9348ce9ae004eea6f958870"

--- a/poetry.lock
+++ b/poetry.lock
@@ -273,13 +273,13 @@ files = [
 
 [[package]]
 name = "celery"
-version = "5.4.0rc1"
+version = "5.3.6"
 description = "Distributed Task Queue."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "celery-5.4.0rc1-py3-none-any.whl", hash = "sha256:0c1067c4b53b5d1a62bdde7a643452ab05e078f5370b5c8e2f2ed50d9ee79c4c"},
-    {file = "celery-5.4.0rc1.tar.gz", hash = "sha256:b7ae1bd7a87ffa9afa1662393032de70188446374abe9f2dfb97c2fa30d9071c"},
+    {file = "celery-5.3.6-py3-none-any.whl", hash = "sha256:9da4ea0118d232ce97dff5ed4974587fb1c0ff5c10042eb15278487cdd27d1af"},
+    {file = "celery-5.3.6.tar.gz", hash = "sha256:870cc71d737c0200c397290d730344cc991d13a057534353d124c9380267aab9"},
 ]
 
 [package.dependencies]
@@ -291,14 +291,14 @@ click-plugins = ">=1.1.1"
 click-repl = ">=0.2.0"
 kombu = ">=5.3.4,<6.0"
 python-dateutil = ">=2.8.2"
-python-memcached = {version = ">=1.61", optional = true, markers = "extra == \"pymemcache\""}
+python-memcached = {version = "1.59", optional = true, markers = "extra == \"pymemcache\""}
 redis = {version = ">=4.5.2,<4.5.5 || >4.5.5,<6.0.0", optional = true, markers = "extra == \"redis\""}
 tzdata = ">=2022.7"
 vine = ">=5.1.0,<6.0"
 
 [package.extras]
 arangodb = ["pyArango (>=2.0.2)"]
-auth = ["cryptography (==41.0.7)"]
+auth = ["cryptography (==41.0.5)"]
 azureblockblob = ["azure-storage-blob (>=12.15.0)"]
 brotli = ["brotli (>=1.0.0)", "brotlipy (>=0.7.0)"]
 cassandra = ["cassandra-driver (>=3.25.0,<4)"]
@@ -308,16 +308,16 @@ couchbase = ["couchbase (>=3.0.0)"]
 couchdb = ["pycouchdb (==1.14.2)"]
 django = ["Django (>=2.2.28)"]
 dynamodb = ["boto3 (>=1.26.143)"]
-elasticsearch = ["elastic-transport (<=8.11.0)", "elasticsearch (<=8.11.1)"]
+elasticsearch = ["elastic-transport (<=8.10.0)", "elasticsearch (<=8.11.0)"]
 eventlet = ["eventlet (>=0.32.0)"]
 gevent = ["gevent (>=1.5.0)"]
 librabbitmq = ["librabbitmq (>=2.0.0)"]
 memcache = ["pylibmc (==1.6.3)"]
 mongodb = ["pymongo[srv] (>=4.0.2)"]
 msgpack = ["msgpack (==1.0.7)"]
-pymemcache = ["python-memcached (>=1.61)"]
+pymemcache = ["python-memcached (==1.59)"]
 pyro = ["pyro4 (==4.82)"]
-pytest = ["pytest-celery (==1.0.0b1)"]
+pytest = ["pytest-celery (==0.0.0)"]
 redis = ["redis (>=4.5.2,!=4.5.5,<6.0.0)"]
 s3 = ["boto3 (>=1.26.143)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
@@ -2076,14 +2076,17 @@ six = ">=1.5"
 
 [[package]]
 name = "python-memcached"
-version = "1.62"
+version = "1.59"
 description = "Pure python memcached client"
 optional = true
 python-versions = "*"
 files = [
-    {file = "python-memcached-1.62.tar.gz", hash = "sha256:0285470599b7f593fbf3bec084daa1f483221e68c1db2cf1d846a9f7c2655103"},
-    {file = "python_memcached-1.62-py2.py3-none-any.whl", hash = "sha256:1bdd8d2393ff53e80cd5e9442d750e658e0b35c3eebb3211af137303e3b729d1"},
+    {file = "python-memcached-1.59.tar.gz", hash = "sha256:a2e28637be13ee0bf1a8b6843e7490f9456fd3f2a4cb60471733c7b5d5557e4f"},
+    {file = "python_memcached-1.59-py2.py3-none-any.whl", hash = "sha256:4dac64916871bd3550263323fc2ce18e1e439080a2d5670c594cf3118d99b594"},
 ]
+
+[package.dependencies]
+six = ">=1.4.0"
 
 [[package]]
 name = "pytz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,18 @@ replace = ':Version: {new_version}'
 
 [tool.poetry.dependencies]
 python = ">= 3.8,<4.0"
-celery = { version = "^5", extras = ["redis", "pymemcache"] }
+celery = { version = "<6.0.0", extras = [
+    "redis",
+    "pymemcache",
+], optional = true }
 retry = "^0.9.2"
 pytest-docker-tools = "^3.1.3"
 docker = "^7.0.0"
 psutil = "^5.9.7"
 setuptools = "^69.0.3"
+
+[tool.poetry.extras]
+celery = ["celery"]
 
 [tool.poetry.group.dev]
 

--- a/src/pytest_celery/vendors/worker/Dockerfile
+++ b/src/pytest_celery/vendors/worker/Dockerfile
@@ -22,7 +22,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Install Python dependencies
 RUN pip install --no-cache-dir --upgrade \
     pip \
-    celery[redis,memcache,pymemcache]${WORKER_VERSION:+==$WORKER_VERSION} \
+    celery[redis,pymemcache]${WORKER_VERSION:+==$WORKER_VERSION} \
     psutil
 
 # The workdir must be /app

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     PYTHONUNBUFFERED = 1
     PYTHONDONTWRITEBYTECODE = 1
 commands_pre =
-    poetry install --with dev,test
+    poetry install -E "celery" --with dev,test
 commands =
     unit: poetry run pytest tests/unit/ --maxfail=3 {posargs}
     integration: poetry run pytest tests/integration/ --exitfirst --dist=loadscope {posargs}
@@ -70,7 +70,7 @@ commands =
 [testenv:mypy]
 description = Run mypy using {basepython}
 commands_pre =
-    poetry install --only dev
+    poetry install -E "celery" --only dev
     poetry run mypy --install-types --non-interactive
 commands =
     poetry run mypy --config-file pyproject.toml
@@ -79,7 +79,7 @@ commands =
 description = Run code+doc lint using {basepython}
 allowlist_externals = poetry, make
 commands_pre =
-    poetry install --with dev,docs
+    poetry install -E "celery" --with dev,docs
 commands =
     poetry run pre-commit {posargs:run --all-files --show-diff-on-failure}
     make -C ./docs apicheck
@@ -90,7 +90,7 @@ commands =
 description = Clean up build and test artifacts using {basepython}
 allowlist_externals = poetry, pytest, bash, find, make
 commands_pre =
-    poetry install --only dev
+    poetry install -E "celery" --only dev
 commands =
     poetry run cleanpy .
     make -C ./docs clean
@@ -103,7 +103,7 @@ commands =
 description = Build docs using {basepython}
 allowlist_externals = poetry, make
 commands_pre =
-    poetry install --with docs
+    poetry install -E "celery" --with docs
 commands =
     make -C ./docs html
 
@@ -111,7 +111,7 @@ commands =
 description = Build docs using {basepython} and serve in http://0.0.0.0:7010
 allowlist_externals = poetry, make
 commands_pre =
-    poetry install --with docs
+    poetry install -E "celery" --with docs
 commands =
     make -C ./docs livehtml
 
@@ -119,6 +119,6 @@ commands =
 description = Regenerate API Reference doc section using {basepython}
 allowlist_externals = poetry, make
 commands_pre =
-    poetry install --with docs
+    poetry install -E "celery" --with docs
 commands =
     make -C ./docs apidoc


### PR DESCRIPTION
For testing and simple use, `pip install pytest-celery[celery]` to take the latest package.
For production environments, celery should already be installed by itself with the versioning and packages the environment uses, so `pip install pytest-celery` should be enough to avoid installing useless packages.