### PR TITLE
Fixed pip deprecation warning about egg fragment with a non-PEP 508 name

### DIFF
--- a/examples/django/requirements.txt
+++ b/examples/django/requirements.txt
@@ -1,5 +1,5 @@
 sqlalchemy>=1.2.18
 django>=2.2.1
 pytest-django>=4.7.0
-git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
+pytest-celery[celery]@git+https://github.com/celery/pytest-celery.git
 pytest-xdist>=3.5.0

--- a/examples/myworker/requirements.txt
+++ b/examples/myworker/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=7.4.4
-git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
+pytest-celery[celery]@git+https://github.com/celery/pytest-celery.git
 pytest-xdist>=3.5.0

--- a/examples/rabbitmq_management/requirements.txt
+++ b/examples/rabbitmq_management/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=7.4.4
-git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
+pytest-celery[celery]@git+https://github.com/celery/pytest-celery.git
 pytest-xdist>=3.5.0

--- a/examples/range/requirements.txt
+++ b/examples/range/requirements.txt
@@ -1,4 +1,4 @@
 pytest>=7.4.4
-git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery]
+pytest-celery[celery]@git+https://github.com/celery/pytest-celery.git
 pytest-xdist>=3.5.0
 pytest-subtests>=0.11.0


### PR DESCRIPTION
```bash
DEPRECATION: git+https://github.com/celery/pytest-celery.git#egg=pytest-celery[celery] contains an 
egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible 
replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be 
found at https://github.com/pypa/pip/issues/11617
```