### PR TITLE
Upgrade to codecov/codecov-action@v4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,9 +67,10 @@ jobs:
           tox --verbose --verbose -e "${{ matrix.python-version }}-unit"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true # optional (default = false)
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)
 
   Integration:


### PR DESCRIPTION
Like #180 but following the directions at
* https://github.com/codecov/codecov-action?tab=readme-ov-file#usage

`token: ${{ secrets.CODECOV_TOKEN }} # required`