### PR TITLE
Revert "Upgrade to codecov/codecov-action@v4"

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,10 +67,9 @@ jobs:
           tox --verbose --verbose -e "${{ matrix.python-version }}-unit"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true # optional (default = false)
-          token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)
 
   Integration:


### PR DESCRIPTION
Reverts celery/pytest-celery#186

@cclauss Unfortunately we need to revert the upgrade to the newer codecov.
The requirement to use a token breaks the dependabot and the fix is not trivial, without reducing security measures.

In short, it does not have access to the token: `"token": null`
```bash
==> Uploader SHASUM verified (103bfefcc56f76473179e600b96eb8150b0f349ad94836b0f63f03ffac469ad7  codecov)
info - 2024-02-12 15:11:36,187 -- ci service found: github-actions
debug - 2024-02-12 15:11:36,188 -- versioning system found: <class 'codecov_cli.helpers.versioning_systems.GitVersioningSystem'>
debug - 2024-02-12 15:11:36,188 -- versioning system found: <class 'codecov_cli.helpers.versioning_systems.GitVersioningSystem'>
warning - 2024-02-12 15:11:36,191 -- No config file could be found. Ignoring config.
debug - 2024-02-12 15:11:36,191 -- No codecov_yaml found
debug - 2024-02-12 15:11:36,196 -- Starting create commit process --- {"commit_sha": "66eabe0c12f6f3254db22393fddb57936995f6c7", "parent_sha": null, "pr": "194", "branch": "dependabot/pip/setuptools-69.1.0", "slug": "celery/pytest-celery", "token": null, "service": "github", "enterprise_url": null}
Error: Codecov token not found. Please provide Codecov token with -t flag.
Error: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```

From this PR: https://github.com/celery/pytest-celery/pull/194