### PR TITLE
Feature: Support for dynamic worker args

### DIFF
--- a/docs/userguide/examples/django.rst
+++ b/docs/userguide/examples/django.rst
@@ -144,6 +144,7 @@ and `container <https://github.com/Jc2k/pytest-docker-tools?tab=readme-ov-file#c
         },
         wrapper_class=DjangoWorkerContainer,
         timeout=defaults.DEFAULT_WORKER_CONTAINER_TIMEOUT,
+        command=fxtr("default_worker_command"),
     )
 
 In this case, we also mount the project directory to ``/src`` in the container, so that we can install the project

--- a/examples/django/tests/conftest.py
+++ b/examples/django/tests/conftest.py
@@ -58,6 +58,7 @@ default_worker_container = container(
     },
     wrapper_class=DjangoWorkerContainer,
     timeout=defaults.DEFAULT_WORKER_CONTAINER_TIMEOUT,
+    command=fxtr("default_worker_command"),
 )
 
 

--- a/src/pytest_celery/api/container.py
+++ b/src/pytest_celery/api/container.py
@@ -71,9 +71,6 @@ class CeleryTestContainer(wrappers.Container):
                 the first element, followed by the command-line arguments.
         """
 
-        # To be used with pytest_docker_tools.container using the command
-        # kwarg with the class method as value
-        # e.g. command=MyContainer.command()
         raise NotImplementedError("CeleryTestContainer.command")
 
     def teardown(self) -> None:

--- a/src/pytest_celery/vendors/redis/backend/fixtures.py
+++ b/src/pytest_celery/vendors/redis/backend/fixtures.py
@@ -50,8 +50,21 @@ default_redis_backend = container(
     network="{default_pytest_celery_network.name}",
     wrapper_class=RedisContainer,
     timeout=REDIS_CONTAINER_TIMEOUT,
-    command=RedisContainer.command("--maxclients", "100000"),
+    command=fxtr("default_redis_backend_command"),
 )
+
+
+@pytest.fixture
+def default_redis_backend_command(default_redis_backend_cls: type[RedisContainer]) -> list[str]:
+    """Command to run the container.
+
+    Args:
+        default_redis_backend_cls (type[RedisContainer]): See also: :ref:`vendor-class`.
+
+    Returns:
+        list[str]: Docker CMD instruction.
+    """
+    return default_redis_backend_cls.command("--maxclients", "100000")
 
 
 @pytest.fixture

--- a/src/pytest_celery/vendors/redis/broker/fixtures.py
+++ b/src/pytest_celery/vendors/redis/broker/fixtures.py
@@ -50,8 +50,21 @@ default_redis_broker = container(
     network="{default_pytest_celery_network.name}",
     wrapper_class=RedisContainer,
     timeout=REDIS_CONTAINER_TIMEOUT,
-    command=RedisContainer.command("--maxclients", "100000"),
+    command=fxtr("default_redis_broker_command"),
 )
+
+
+@pytest.fixture
+def default_redis_broker_command(default_redis_broker_cls: type[RedisContainer]) -> list[str]:
+    """Command to run the container.
+
+    Args:
+        default_redis_broker_cls (type[RedisContainer]): See also: :ref:`vendor-class`.
+
+    Returns:
+        list[str]: Docker CMD instruction.
+    """
+    return default_redis_broker_cls.command("--maxclients", "100000")
 
 
 @pytest.fixture

--- a/src/pytest_celery/vendors/worker/container.py
+++ b/src/pytest_celery/vendors/worker/container.py
@@ -32,6 +32,22 @@ class CeleryWorkerContainer(CeleryTestContainer):
         dependencies of your project.
     """
 
+    @classmethod
+    def command(cls, *args: str) -> list[str]:
+        args = args or tuple()
+        return [
+            "celery",
+            "-A",
+            "app",
+            "worker",
+            f"--loglevel={cls.log_level()}",
+            "-n",
+            f"{cls.worker_name()}@%h",
+            "-Q",
+            f"{cls.worker_queue()}",
+            *args,
+        ]
+
     def _wait_port(self, port: str) -> int:
         # Not needed for worker container
         raise NotImplementedError

--- a/src/pytest_celery/vendors/worker/fixtures.py
+++ b/src/pytest_celery/vendors/worker/fixtures.py
@@ -91,6 +91,7 @@ default_worker_container = container(
     volumes={"{default_worker_volume.name}": DEFAULT_WORKER_VOLUME},
     wrapper_class=CeleryWorkerContainer,
     timeout=DEFAULT_WORKER_CONTAINER_TIMEOUT,
+    command=fxtr("default_worker_command"),
 )
 
 celery_base_worker_image = build(
@@ -162,6 +163,19 @@ def default_worker_celery_worker_queue(default_worker_container_session_cls: typ
 
 
 @pytest.fixture
+def default_worker_command(default_worker_container_cls: type[CeleryWorkerContainer]) -> list[str]:
+    """Command to run the container.
+
+    Args:
+        default_worker_container_cls (type[CeleryWorkerContainer]): See also: :ref:`vendor-class`.
+
+    Returns:
+        list[str]: Docker CMD instruction.
+    """
+    return default_worker_container_cls.command()
+
+
+@pytest.fixture
 def default_worker_env(
     default_worker_container_cls: type[CeleryWorkerContainer],
     celery_worker_cluster_config: dict,
@@ -201,7 +215,7 @@ def default_worker_initial_content(
 
     .. note::
 
-        Move volumes may be added additionally.
+        More volumes may be added additionally.
 
     Args:
         default_worker_container_cls (type[CeleryWorkerContainer]): See also: :ref:`vendor-class`.

--- a/tests/integration/api/custom_setup/conftest.py
+++ b/tests/integration/api/custom_setup/conftest.py
@@ -110,6 +110,7 @@ default_worker_container = container(
     volumes={"{default_worker_volume.name}": DEFAULT_WORKER_VOLUME},
     wrapper_class=Celery5WorkerContainer,
     timeout=DEFAULT_WORKER_CONTAINER_TIMEOUT,
+    command=fxtr("default_worker_command"),
 )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,4 +56,5 @@ default_worker_container = container(
     volumes={"{default_worker_volume.name}": DEFAULT_WORKER_VOLUME},
     wrapper_class=IntegrationWorkerContainer,
     timeout=DEFAULT_WORKER_CONTAINER_TIMEOUT,
+    command=fxtr("default_worker_command"),
 )

--- a/tests/integration/vendors/test_worker.py
+++ b/tests/integration/vendors/test_worker.py
@@ -50,6 +50,14 @@ class test_celery_worker_container:
         def test_replacing_app_module(self, container: CeleryWorkerContainer, default_worker_app_module: ModuleType):
             assert container.app_module() == default_worker_app_module
 
+    class test_replacing_command:
+        @pytest.fixture
+        def default_worker_command(self, default_worker_command: list[str]) -> list[str]:
+            return [*default_worker_command, "--pool", "solo"]
+
+        def test_replacing_command(self, container: CeleryWorkerContainer):
+            assert container.logs().count("solo") == 1
+
 
 class test_base_test_worker:
     def test_config(self, celery_setup_worker: CeleryTestWorker):

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -102,6 +102,7 @@ default_worker_container = container(
     volumes={"{default_worker_volume.name}": DEFAULT_WORKER_VOLUME},
     wrapper_class=SmokeWorkerContainer,
     timeout=DEFAULT_WORKER_CONTAINER_TIMEOUT,
+    command=fxtr("default_worker_command"),
 )
 
 

--- a/tests/smoke/test_worker.py
+++ b/tests/smoke/test_worker.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from pytest_celery import CeleryTestSetup
+
+
+@pytest.mark.parametrize(
+    "pool",
+    [
+        "solo",
+        "prefork",
+        "threads",
+    ],
+)
+class test_replacing_pool:
+    @pytest.fixture
+    def default_worker_command(self, default_worker_command: list[str], pool: str) -> list[str]:
+        return [*default_worker_command, "--pool", pool]
+
+    def test_pool_from_celery_banner(self, celery_setup: CeleryTestSetup, pool: str):
+        if pool == "threads":
+            pool = "thread"
+        celery_setup.worker.assert_log_exists(pool)


### PR DESCRIPTION
Added `default_worker_command` fixture to allow configuring the worker’s cmdline without touching the docker stuff.
Added test shows example for changing the `—pool` configuration.

**Requires adding `command=fxtr("default_worker_command”)` to all default worker containers overrides, everywhere!**