### PR TITLE
make celery a required dependency and the celery extra's optional dependencies

### DIFF
--- a/src/pytest_celery/__init__.py
+++ b/src/pytest_celery/__init__.py
@@ -24,17 +24,27 @@ from pytest_celery.fixtures.backend import *
 from pytest_celery.fixtures.broker import *
 from pytest_celery.fixtures.setup import *
 from pytest_celery.fixtures.worker import *
-from pytest_celery.vendors.memcached.api import *
-from pytest_celery.vendors.memcached.container import *
-from pytest_celery.vendors.memcached.fixtures import *
+from pytest_celery.vendors import MissingCeleryDependency
 from pytest_celery.vendors.rabbitmq.api import *
 from pytest_celery.vendors.rabbitmq.container import *
 from pytest_celery.vendors.rabbitmq.fixtures import *
-from pytest_celery.vendors.redis.backend.api import *
-from pytest_celery.vendors.redis.backend.fixtures import *
-from pytest_celery.vendors.redis.broker.api import *
-from pytest_celery.vendors.redis.broker.fixtures import *
-from pytest_celery.vendors.redis.container import *
+
+try:
+    from pytest_celery.vendors.memcached.api import *
+    from pytest_celery.vendors.memcached.container import *
+    from pytest_celery.vendors.memcached.fixtures import *
+except MissingCeleryDependency:
+    pass
+
+try:
+    from pytest_celery.vendors.redis.backend.api import *
+    from pytest_celery.vendors.redis.backend.fixtures import *
+    from pytest_celery.vendors.redis.broker.api import *
+    from pytest_celery.vendors.redis.broker.fixtures import *
+    from pytest_celery.vendors.redis.container import *
+except MissingCeleryDependency:
+    pass
+
 from pytest_celery.vendors.worker.container import *
 from pytest_celery.vendors.worker.fixtures import *
 

--- a/src/pytest_celery/defaults.py
+++ b/src/pytest_celery/defaults.py
@@ -4,17 +4,34 @@ from __future__ import annotations
 
 from pytest_docker_tools import network
 
-from pytest_celery.vendors.memcached.defaults import CELERY_MEMCACHED_BACKEND
-from pytest_celery.vendors.memcached.defaults import *
+from pytest_celery.vendors import MissingCeleryDependency
 from pytest_celery.vendors.rabbitmq.defaults import CELERY_RABBITMQ_BROKER
 from pytest_celery.vendors.rabbitmq.defaults import *
-from pytest_celery.vendors.redis.backend.defaults import CELERY_REDIS_BACKEND
-from pytest_celery.vendors.redis.backend.defaults import *
-from pytest_celery.vendors.redis.broker.defaults import CELERY_REDIS_BROKER
-from pytest_celery.vendors.redis.broker.defaults import *
-from pytest_celery.vendors.redis.defaults import *
 from pytest_celery.vendors.worker.defaults import CELERY_SETUP_WORKER
 from pytest_celery.vendors.worker.defaults import *
+
+try:
+    import pytest_celery.vendors.memcached
+except MissingCeleryDependency:
+    _CELERY_MEMCACHED_BACKEND = None
+else:
+    from pytest_celery.vendors.memcached.defaults import CELERY_MEMCACHED_BACKEND as _CELERY_MEMCACHED_BACKEND
+    from pytest_celery.vendors.memcached.defaults import *
+
+    _CELERY_MEMCACHED_BACKEND = None  # Beta support at the moment, to be used manually
+
+try:
+    import pytest_celery.vendors.redis
+except MissingCeleryDependency:
+    _CELERY_REDIS_BACKEND = None
+    _CELERY_REDIS_BROKER = None
+else:
+    from pytest_celery.vendors.redis.backend.defaults import CELERY_REDIS_BACKEND as _CELERY_REDIS_BACKEND
+    from pytest_celery.vendors.redis.backend.defaults import *
+    from pytest_celery.vendors.redis.broker.defaults import CELERY_REDIS_BROKER as _CELERY_REDIS_BROKER
+    from pytest_celery.vendors.redis.broker.defaults import *
+    from pytest_celery.vendors.redis.defaults import *
+
 
 ####################################################################################
 # Automatic components
@@ -29,14 +46,8 @@ from pytest_celery.vendors.worker.defaults import *
 # Tests that do not rely on default parametrization will not be affected.
 
 ALL_CELERY_WORKERS = (CELERY_SETUP_WORKER,)
-ALL_CELERY_BACKENDS = (
-    CELERY_REDIS_BACKEND,
-    # CELERY_MEMCACHED_BACKEND,  # Beta support at the moment, to be used manually
-)
-ALL_CELERY_BROKERS = (
-    CELERY_REDIS_BROKER,
-    CELERY_RABBITMQ_BROKER,
-)
+ALL_CELERY_BACKENDS = (backend for backend in [_CELERY_REDIS_BACKEND, _CELERY_MEMCACHED_BACKEND] if backend is not None)
+ALL_CELERY_BROKERS = (broker for broker in [CELERY_RABBITMQ_BROKER, _CELERY_REDIS_BROKER] if broker is not None)
 
 ####################################################################################
 # Fixtures

--- a/src/pytest_celery/vendors/__init__.py
+++ b/src/pytest_celery/vendors/__init__.py
@@ -1,1 +1,5 @@
 """See :ref:`vendors`."""
+
+
+class MissingCeleryDependency(ImportError):
+    pass

--- a/src/pytest_celery/vendors/memcached/__init__.py
+++ b/src/pytest_celery/vendors/memcached/__init__.py
@@ -3,3 +3,10 @@
 
 This module is part of the Memcached Backend vendor.
 """
+
+from .. import MissingCeleryDependency
+
+try:
+    import memcache  # noqa F401
+except ImportError as e:
+    raise MissingCeleryDependency("celery extra dependency missing: celery[pymemcache]") from e

--- a/src/pytest_celery/vendors/redis/__init__.py
+++ b/src/pytest_celery/vendors/redis/__init__.py
@@ -3,3 +3,10 @@
 
 This module is part of the Redis vendor.
 """
+
+from .. import MissingCeleryDependency
+
+try:
+    import redis  # noqa F401
+except ImportError as e:
+    raise MissingCeleryDependency("celery extra dependency missing: celery[redis]") from e


### PR DESCRIPTION
The modifications in https://github.com/celery/pytest-celery/pull/172 can cause issues like https://github.com/celery/pytest-celery/issues/205.

When installing `pytest-redis` without `celery[redis,pymemcache]`, pytest becomes unusable because the pytest plugin system causes `pytest-redis` to be imported, which in turn imports `celery`, `redis` and `memcache`.

For example

```
pip install pytest-redis

pytest -h

Traceback (most recent call last):
  ...
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/users/denolf/virtualenvs/pybox_VH60vO/ubuntu_20_04/py38/lib/python3.8/site-packages/pluggy/_manager.py", line 414, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/users/denolf/.pyenv/ubuntu_20_04/versions/3.8.5/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  ...
  File "/users/denolf/virtualenvs/pybox_VH60vO/ubuntu_20_04/py38/lib/python3.8/site-packages/pytest_celery/api/backend.py", line 9, in <module>
    from pytest_celery.api.base import CeleryTestCluster
  File "/users/denolf/virtualenvs/pybox_VH60vO/ubuntu_20_04/py38/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 175, in exec_module
    exec(co, module.__dict__)
  File "/users/denolf/virtualenvs/pybox_VH60vO/ubuntu_20_04/py38/lib/python3.8/site-packages/pytest_celery/api/base.py", line 15, in <module>
    from celery import Celery
ModuleNotFoundError: No module named 'celery'
```

We could make `celery` an optional dependency of `pytest-redis` but I doubt this is meaningful. What is meaningful is to make the celery extra's optional: `celery[redis]` and `celery[pymemcache]`.

That's what I tried to do in this MR by making the `memcached` and `redis` vendor modules optional. I would like to do this

```
[options]
install_requires = 
    celery<6.0.0

[options.extras_require]
full =
    celery[redis,pymemcached]
```

But I cannot figure out how to do this in `poetry` (I believe https://github.com/python-poetry/poetry-core/pull/613 is needed for that). For now I did this

```
[tool.poetry.dependencies]
celery = { version = "<6.0.0" }
redis = { version = ">=4.5.2,<6.0.0,!=4.5.5", optional = true }
python-memcached = { version = ">=1.61", optional = true }

[tool.poetry.extras]
full = ["redis", "python-memcached"]
```

but this means we are managing the `redis` and `python-memcached` version limits ourselves which is not what we want.

**Edit**: https://github.com/python-poetry/poetry-core/pull/613#issuecomment-1690169335 shows that there is a way to do it in poetry

```
[tool.poetry.dependencies]
celery = [
    { version = "<6.0.0" },
    { version = "<6.0.0", extras = ["redis", "pymemcache"], markers = "extra == 'full'" }
]

[tool.poetry.extras]
full = []
```