### PR TITLE
Refactor default_worker_tasks fixture in pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
 import pytest
-
+from tests import tasks
 
 @pytest.fixture
-def default_worker_tasks(default_worker_tasks: set) -> set:
-    from tests import tasks
-
+def default_worker_tasks():
+    default_worker_tasks = set()
     default_worker_tasks.add(tasks)
     return default_worker_tasks


### PR DESCRIPTION
Updated the default_worker_tasks fixture in pytest to remove circular dependency and improve readability. The fixture now correctly initializes the set and adds tasks from the tests module.

- Refactored the `default_worker_tasks` fixture in pytest to address a circular dependency issue and improve readability. Previously, the fixture had a circular dependency problem where it tried to reference itself within its definition, which could lead to unexpected behavior.

- The updated code initializes the `default_worker_tasks` set correctly and then adds tasks from the tests module. This change ensures that the fixture is correctly defined and provides a clear separation of concerns, making the code more maintainable and easier to understand.