### PR TITLE
Replace outdated dependency with security flags

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3114,4 +3114,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "d0b54e85fef75566921e392430e4b385dec83e2708a056b574a3593421fadd63"
+content-hash = "9574558a485eed7f158b72bfb778f60740057712f3ec5f4eff1e554b63c4e9cf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -791,17 +791,6 @@ files = [
 ]
 
 [[package]]
-name = "decorator"
-version = "5.1.1"
-description = "Decorators for Humans"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
-    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
-]
-
-[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -1020,6 +1009,17 @@ files = [
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.11.0,<2.12.0"
 pyflakes = ">=3.2.0,<3.3.0"
+
+[[package]]
+name = "funcy"
+version = "2.0"
+description = "A fancy and practical functional tools"
+optional = false
+python-versions = "*"
+files = [
+    {file = "funcy-2.0-py2.py3-none-any.whl", hash = "sha256:53df23c8bb1651b12f095df764bfb057935d49537a56de211b098f4c79614bb0"},
+    {file = "funcy-2.0.tar.gz", hash = "sha256:3963315d59d41c6f30c04bc910e10ab50a3ac4a225868bfa96feed133df075cb"},
+]
 
 [[package]]
 name = "identify"
@@ -2363,21 +2363,6 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "retry"
-version = "0.9.2"
-description = "Easy to use retry decorator."
-optional = false
-python-versions = "*"
-files = [
-    {file = "retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606"},
-    {file = "retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"},
-]
-
-[package.dependencies]
-decorator = ">=3.4.2"
-py = ">=1.4.26,<2.0.0"
-
-[[package]]
 name = "secretstorage"
 version = "3.3.3"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -3129,4 +3114,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "34f88a9458401d50f898aaadc5b52d7f109c47f9163fae9d968670a8b9a009cb"
+content-hash = "61a211112942e5819c6f9fe43c9ecaba66c8c01083d4c7bacfb66abd775e8451"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ celery = { version = "*" }
 redis = { version = "*", optional = true }
 python-memcached = { version = "*", optional = true }
 python = ">=3.8,<4.0"
-retry = ">=0.9.2"
+funcy = ">=2.0"
 pytest-docker-tools = ">=3.1.3"
 docker = "^7.0.0"
 psutil = ">=5.9.7"

--- a/src/pytest_celery/api/container.py
+++ b/src/pytest_celery/api/container.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from typing import Any
 
 import pytest_docker_tools
+from funcy import retry
 from pytest_docker_tools import wrappers
 from pytest_docker_tools.wrappers.container import wait_for_callable
-from retry import retry
 
 
 class CeleryTestContainer(wrappers.Container):
@@ -115,7 +115,7 @@ class CeleryTestContainer(wrappers.Container):
         _, p = self.get_addr(port)
         return p
 
-    @retry(pytest_docker_tools.exceptions.TimeoutError, delay=10, tries=3)
+    @retry(3, timeout=10, errors=pytest_docker_tools.exceptions.TimeoutError)
     def _wait_ready(self, timeout: int = 30) -> bool:
         """Wait for the container to be ready by polling the logs for the
         readiness prompt. If no prompt is set, the container is considered


### PR DESCRIPTION
`pytest-celery` raises security scan alert (e.g. https://github.com/iterative/dvc-task/actions/runs/8883067284/job/24389104408?pr=128)

It depends on `retry` libm which itself depends (for no good reason) on `py` which is flagged for security and is outdated:

https://github.com/invl/retry/issues/58
https://github.com/invl/retry/pull/60

It seems it's not maintained (last release / update is ~8 years ago).

A replacement is `funcy` - lightweight (no dependencies AFAIK), license is good, maintained. We have been using it in DVC.org for a while.

