### PR TITLE
Changed --reruns 3 -> 5 in the CI for hybrid_setup example (to mitigate docker failures)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -298,7 +298,7 @@ jobs:
         working-directory: examples/hybrid_setup
         timeout-minutes: 10
         run: |
-          pytest -xsv tests --reruns 3 --rerun-except AssertionError
+          pytest -xsv tests --reruns 5 --rerun-except AssertionError
 
   vhost:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
To reduce false negatives failures