### PR TITLE
fix: invalid SPDX license ID in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ classifiers = [
 
 description = "Pytest plugin for Celery"
 homepage = "https://github.com/celery/pytest-celery"
-license = "BSD"
+license = "BSD-3-Clause"
 name = "pytest-celery"
 version = "1.1.3"
 readme = "README.rst"


### PR DESCRIPTION
The project was using a non-existent SPDX license ID ("BSD") which lead Poetry to mark the project under a proprietary license (fallback).

For example, this can be observed at https://pypi.org/pypi/pytest-celery/1.1.3/json, where we can see the following classifier:

```
License :: Other/Proprietary License
```

Explanation: when poetry doesn't know the license (unable to match the license against the [SPDX license ID list](https://spdx.org/licenses/)), it falls back to "Proprietary"[^1][^2].

This can cause tools checking for license compliance to mistakenly flag the project as non-compliant.

----

The changes were tested locally as follows:

```bash
$ poetry build -f sdist
$ cd dist/
$ tar -xf pytest_celery-1.1.3.tar.gz
$ grep 'Classifier: License' pytest_celery-1.1.3/PKG-INFO'
```

Before:

```
$ grep 'Classifier: License' pytest_celery-1.1.3-old/PKG-INFO
Classifier: License :: OSI Approved :: BSD License
Classifier: License :: Other/Proprietary License
```

After:

```
$ grep 'Classifier: License' pytest_celery-1.1.3-fixed/PKG-INFO
Classifier: License :: OSI Approved :: BSD License
```

Full diffs for `PKG-INFO`:


```diff
$ diff -u pytest_celery-1.1.3-{old,fixed}/PKG-INFO
--- pytest_celery-1.1.3-old/PKG-INFO	1970-01-01 01:00:00
+++ pytest_celery-1.1.3-fixed/PKG-INFO	1970-01-01 01:00:00
@@ -3,7 +3,7 @@
 Version: 1.1.3
 Summary: Pytest plugin for Celery
 Home-page: https://github.com/celery/pytest-celery
-License: BSD
+License: BSD-3-Clause
 Keywords: pytest,celery
 Author: Tomer Nosrati
 Author-email: tomer.nosrati@gmail.com
@@ -11,7 +11,6 @@
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Framework :: Celery
 Classifier: License :: OSI Approved :: BSD License
-Classifier: License :: Other/Proprietary License
 Classifier: Operating System :: OS Independent
 Classifier: Programming Language :: Python
 Classifier: Programming Language :: Python :: 3
```

</details>

[^1]: https://github.com/python-poetry/poetry-core/blob/5d3abc51bb765d825f3162f34595d853b249a8eb/tests/spdx/test_license.py#L44-L47
[^2]: https://github.com/python-poetry/poetry-core/blob/ab1bdf32fbe283c3e03ea77cf55b008819b6549e/src/poetry/core/spdx/license.py#L156-L160