### PR TITLE
Update `worker` `Dockerfile` image to `bookworm`

### DIFF
--- a/src/pytest_celery/vendors/worker/Dockerfile
+++ b/src/pytest_celery/vendors/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.10-slim-bookworm
 
 # Create a user to run the worker
 RUN adduser --disabled-password --gecos "" test_user


### PR DESCRIPTION
Upgrade the image used for the `pytest_celery_worker` from the `python:3.10-slim-buster` to the `python:3.10-slim-bookworm` image, because the `buster` images are on Debian 10, and it has already left the LTS, so therefore its package mirrors were moved from deb.debian.org to archive.debian.org.

Once that happened, apt-get update inside the image began getting 404 / Release-file-missing errors, and the next apt-get install bailed out with exit code 100.

To reproduce on the `main` branch run:
```bash
cd src/pytest_celery/vendors/worker

docker build --no-cache .
```

You will see an output like this:
```
docker build --no-cache .

[+] Building 0.9s (7/10)                                                                                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.0s
 => => transferring dockerfile: 1.26kB                                                                                                                                                                        0.0s
 => WARN: JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 52)                                                                              0.0s
 => [internal] load metadata for docker.io/library/python:3.10-slim-buster                                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => CACHED [1/6] FROM docker.io/library/python:3.10-slim-buster                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                             0.0s
 => => transferring context: 1.65kB                                                                                                                                                                           0.0s
 => [2/6] RUN adduser --disabled-password --gecos "" test_user                                                                                                                                                0.2s
 => ERROR [3/6] RUN apt-get update && apt-get install -y build-essential     git     wget     make     curl     apt-utils     debconf     lsb-release     libmemcached-dev     libffi-dev     ca-certificate  0.7s
------                                                                                                                                                                                                             
 > [3/6] RUN apt-get update && apt-get install -y build-essential     git     wget     make     curl     apt-utils     debconf     lsb-release     libmemcached-dev     libffi-dev     ca-certificates     pypy3     pypy3-lib     sudo:                                                                                                                                                                                              
0.228 Ign:1 http://deb.debian.org/debian buster InRelease                                                                                                                                                          
0.367 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease                                                                                                                                         
0.387 Ign:3 http://deb.debian.org/debian buster-updates InRelease                                                                                                                                                  
0.407 Err:4 http://deb.debian.org/debian buster Release
0.407   404  Not Found [IP: 199.232.66.132 80]
0.548 Err:5 http://deb.debian.org/debian-security buster/updates Release
0.548   404  Not Found [IP: 199.232.66.132 80]
0.568 Err:6 http://deb.debian.org/debian buster-updates Release
0.568   404  Not Found [IP: 199.232.66.132 80]
0.577 Reading package lists...
0.590 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.590 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
0.590 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
------

 1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 52)
Dockerfile:7
--------------------
   6 |     # Install system dependencies
   7 | >>> RUN apt-get update && apt-get install -y build-essential \
   8 | >>>     git \
   9 | >>>     wget \
  10 | >>>     make \
  11 | >>>     curl \
  12 | >>>     apt-utils \
  13 | >>>     debconf \
  14 | >>>     lsb-release \
  15 | >>>     libmemcached-dev \
  16 | >>>     libffi-dev \
  17 | >>>     ca-certificates \
  18 | >>>     pypy3 \
  19 | >>>     pypy3-lib \
  20 | >>>     sudo
  21 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y build-essential     git     wget     make     curl     apt-utils     debconf     lsb-release     libmemcached-dev     libffi-dev     ca-certificates     pypy3     pypy3-lib     sudo" did not complete successfully: exit code: 100
```

Then on my branch, you will see the same command run without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to a newer version for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->