### PR TITLE
ci: Drop the archived GitHub Action useblacksmith/setup-python

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt update
 
       - name: Set up Python 3.13
-        uses: useblacksmith/setup-python@v6
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: 'pip'


### PR DESCRIPTION
Like:
* celery/django-celery-beat#1062

As recommended in the ***archive notice*** for the GitHub Action `useblacksmith/setup-python`:
* https://github.com/useblacksmith/setup-python#%EF%B8%8F-archive-notice
> Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect, it is recommended to switch to the upstream, maintained versions of this action, as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.