### PR TITLE
pre-commit: Upgrade pyupgrade for Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: yesqa
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]


### PR DESCRIPTION
Unblock:
* #472
```diff
  - repo: https://github.com/asottile/pyupgrade
-   rev: v3.19.1
+   rev: v3.21.2
```
https://github.com/asottile/pyupgrade/tags

***Before:***
% `pre-commit run pyupgrade --all-files`
```
TypeError: cannot use a bytes pattern on a string-like object
```
***After:***
% `pre-commit run pyupgrade --all-files`
```
pyupgrade................................................................Passed
```