### PR TITLE
ci: Fix lint-check by removing a broken link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -135,4 +135,3 @@ Tomer Nosrati
 
 :web: http://tomernosrati.com/
 :github: https://github.com/Nusnus
-:x: https://x.com/tomer_nosrati


### PR DESCRIPTION
* #488

@Nusnus This line seems to be causing the `Linter` job to fail.
https://github.com/celery/pytest-celery/blob/33cfddbcdb010129bb56f7daa9d969ef00a547fb/CONTRIBUTING.rst?plain=1#L138

https://github.com/celery/pytest-celery/actions/runs/28700962399/job/85118789113?pr=488#step:8:491
> ( contributing: line 138) broken https://x.com/tomer_nosrati - 404 Client Error: Not Found for url: https://x.com/tomer_nosrati
