### PR TITLE
Fix misspelling of 'REDACTED' in changelog

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -45,7 +45,7 @@ Changelog
 What's Changed
 ==============
 
-- Fixed spelling REDUCTED -> REDACTED, found by codespell (#446)
+- Fixed a misspelling of REDACTED, found by codespell (#446)
 - Added DeepWiki to README (#453)
 - Synced donation section in the docs to celery (#454)
 - Bumping Dependencies (poetry update --with test,dev,ci,docs) (#457)


### PR DESCRIPTION
* #446

I would avoid putting the misspelling in the commit title because many repos publish changelogs with the title of landed pull requests, which perpetuates the misspelling in the docs.  This means that typo discovery tools such as [`codespell`](https://pypi.org/project/codespell) will need to have that typo added to their `--ignore-words-list` and will become blind to future regressions.

Unblocks:
* #472